### PR TITLE
move dependencies around 

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,3 +1,4 @@
 [ignore]
 <PROJECT_ROOT>/.*/src/bower.json
 <PROJECT_ROOT>/node_modules/json/.*
+<PROJECT_ROOT>/node_modules/protobuf2flowtype-runtime/node_modules/protobufjs/src/bower.json

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,4 @@
 [ignore]
 <PROJECT_ROOT>/.*/src/bower.json
 <PROJECT_ROOT>/node_modules/json/.*
-<PROJECT_ROOT>/node_modules/protobuf2flowtype-runtime/node_modules/protobufjs/src/bower.json
+.*/node_modules/protobuf2flowtype-runtime/node_modules/protobufjs/src/bower.json

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,3 +1,3 @@
 [ignore]
-<PROJECT_ROOT>/node_modules/protobufjs/src/bower.json
+<PROJECT_ROOT>/.*node_modules/.*protobufjs/src/bower.json
 <PROJECT_ROOT>/node_modules/json/.*

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,3 +1,3 @@
 [ignore]
-<PROJECT_ROOT>/.*node_modules/.*protobufjs/src/bower.json
+<PROJECT_ROOT>/.*/src/bower.json
 <PROJECT_ROOT>/node_modules/json/.*

--- a/package.json
+++ b/package.json
@@ -7,25 +7,24 @@
     "protobuf2flowtype": "build/generate-cli.js"
   },
   "dependencies": {
+    "babel-generator": "^6.14.0",
+    "babylon": "^6.10.0",
+    "fs-extra": "^0.30.0",
+    "mustache": "^2.2.1",
     "protobuf2flowtype-runtime": "2.0.7",
-    "protobufjs": "^5.0.1"
+    "yargs": "^6.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "babel-generator": "^6.14.0",
-    "babylon": "^6.10.0",
     "eslint": "^3.7.1",
     "eslint-plugin-flowtype": "^2.17.1",
     "flow-bin": "^0.33.0",
-    "fs-extra": "^0.30.0",
     "json": "^9.0.4",
     "mock-cli": "^0.1.2",
     "mock-require": "^1.3.0",
-    "mustache": "^2.2.1",
     "nodeunit": "^0.10.2",
     "nyc": "^8.3.0",
-    "rewire": "^2.5.2",
-    "yargs": "^6.0.0"
+    "rewire": "^2.5.2"
   },
   "scripts": {
     "test": "eslint build/ && eslint tests/ && nyc nodeunit tests/**/* && flow && if ! flow check-contents examples/simple-bad.js < examples/simple-bad.js | grep 'Found 3 errors'; then echo 'Flow Checking of simple-bad should fail with 3 Errors'; exit 1; fi && if ! flow check-contents examples/complex-bad.js < examples/complex-bad.js | grep 'Found 11 errors'; then echo 'Flow Checking of complex-bad should fail with 11 Errors'; exit 1; fi",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mock-require": "^1.3.0",
     "nodeunit": "^0.10.2",
     "nyc": "^8.3.0",
+    "protobufjs": "^5.0.1",
     "rewire": "^2.5.2"
   },
   "scripts": {

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -12,5 +12,8 @@
   "bugs": {
     "url": "https://github.com/netproteus/protobuf2flowtype/issues"
   },
-  "homepage": "https://github.com/netproteus/protobuf2flowtype#readme"
+  "homepage": "https://github.com/netproteus/protobuf2flowtype#readme",
+  "dependencies": {
+    "protobufjs": "^5.0.1"
+  }
 }


### PR DESCRIPTION
Messed up the dependency types

so protobuf2flowtype can be installed as devdependency and protobuf2flowtype-runtime can be installed as main dep
