### PR TITLE
export builder types as classses

### DIFF
--- a/build/generate.js
+++ b/build/generate.js
@@ -144,7 +144,10 @@ class Namespace {
 
         this.children.forEach(child => child.generate(jsonDescriptor, moduleTemplate, rootTemplate));
 
-        const imports = [];
+        const imports = {
+            types: [],
+            clazz: []
+        };
         const localTypes = {};
 
 
@@ -283,28 +286,33 @@ class Namespace {
         switch (typeClassification) {
             case 'message':
 
-                if (imports.filter(imp => imp.types[0].alias === (alias + 'Interface')).length > 0) {
+                if (imports.types.filter(imp => imp.names[0].alias === (alias + 'Interface')).length > 0) {
                     break;
                 }
 
-                imports.push({
-                    types: [{
+                imports.types.push({
+                    names: [{
                         name: name + 'Interface',
                         alias: alias + 'Interface'
-                    }, {
+                    }], location: prefix + '/' + namespace.name.replace(/\./g, '/')
+                });
+
+                imports.clazz.push({
+                    names: [{
                         name: name + 'Builder',
                         alias: alias + 'Builder'
                     }], location: prefix + '/' + namespace.name.replace(/\./g, '/')
                 });
+
                 break;
             case 'enum':
 
-                if (imports.filter(imp => imp.types[0].alias === (alias + 'Values')).length > 0) {
+                if (imports.types.filter(imp => imp.names[0].alias === (alias + 'Values')).length > 0) {
                     break;
                 }
 
-                imports.push({
-                    types: [{
+                imports.types.push({
+                    names: [{
                         name: name + 'Values',
                         alias: alias + 'Values'
                     }], location: prefix + '/' + namespace.name.replace(/\./g, '/')

--- a/build/templates/module.js.mt
+++ b/build/templates/module.js.mt
@@ -23,11 +23,21 @@ exports.builder = _.builder;
 
     {{#imports}}
 
-    import type {
-      {{#types}}
-         {{name}} as {{alias}},
-      {{/types}}
-    } from '{{{location}}}';
+        {{#types}}
+            import type {
+                {{#names}}
+                    {{name}} as {{alias}},
+                {{/names}}
+            } from '{{{location}}}';
+        {{/types}}
+
+        {{#clazz}}
+            import {
+                {{#names}}
+                    {{name}} as {{alias}},
+                {{/names}}
+            } from '{{{location}}}';
+        {{/clazz}}
 
     {{/imports}}
 
@@ -85,12 +95,17 @@ exports.builder = _.builder;
 
     export type {
         {{#messages}}
-            {{name}}Interface, {{name}}Builder, {{name}}Reflect,
+            {{name}}Interface, {{name}}Reflect,
         {{/messages}}
         {{#enums}}
             {{name}}Values, {{name}}Options,
         {{/enums}}
     };
+
+    {{#messages}}
+        export { {{name}}Builder };
+    {{/messages}}
+
 /*$ */
 
     const namespace /*: {{dollar}} */ = _.builder.build('{{dots}}');

--- a/tests/build/generate.test.js
+++ b/tests/build/generate.test.js
@@ -459,7 +459,7 @@ module.exports = {
                     return result + msg.oneOfs.length;
                 }, 0),
                 enums: ctx.package.enums.length,
-                imports: ctx.package.imports.length
+                imports: ctx.package.imports.types.length
             }) || {};
 
         }


### PR DESCRIPTION
It's more useful to have declared class types for builders imported/exported as classes
So they can be used in Class<> types by the client
