### PR TITLE
cope with multiple imports of the same file

### DIFF
--- a/build/generate.js
+++ b/build/generate.js
@@ -464,7 +464,7 @@ function camelCase(str, next) {
  * @param protoFile
  * @returns {Namespace}
  */
-function processProto(protoFile, root) {
+function processProto(protoFile, root, imported = []) {
     const protPath = path.format({
         dir: root,
         base: protoFile
@@ -472,7 +472,12 @@ function processProto(protoFile, root) {
     const parser = new ProtoBuf.DotProto.Parser(fs.readFileSync(protPath));
     const protoAst = parser.parse();
 
-    protoAst.imports.forEach(file => processProto(file, root));
+    imported.push(protoFile);
+    protoAst.imports.forEach(file => {
+        if (imported.indexOf(file) === -1) {
+            processProto(file, root, imported);
+        }
+    });
 
     return Namespace.getNamespace(protoAst.package).update(protoAst);
 }

--- a/examples/complex/module1.proto
+++ b/examples/complex/module1.proto
@@ -1,5 +1,7 @@
 package com.foobar.module1;
 
+import "base.proto";
+
 message Module1Test {
 
     message SubMessage {


### PR DESCRIPTION
if a protobuf file was imported in multiple places the generated code would try to import twice. This prevents processing of imports twice